### PR TITLE
Adds configurable undo history depth 

### DIFF
--- a/resources/config.yml
+++ b/resources/config.yml
@@ -21,7 +21,7 @@ tool-cooldown: 0.2
 #Whether to allow user with "easyedit.history.other" permission to undo/redo other people's actions
 allow-history-other: true
 
-#Maximum amount of undo/redo steps
+#Maximum amount of undo/redo steps; for maximum steps, also the default: -1
 history-depth: -1
 
 #Remaps usages of 3 or more slashes to 2 slashes, allowing usage of minecraft autocomplete

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -21,6 +21,9 @@ tool-cooldown: 0.2
 #Whether to allow user with "easyedit.history.other" permission to undo/redo other people's actions
 allow-history-other: true
 
+#Maximum amount of undo/redo steps
+history-depth: -1
+
 #Remaps usages of 3 or more slashes to 2 slashes, allowing usage of minecraft autocomplete
 #Disable this if you have commands requiring 3 slashes
 remap-commands: true

--- a/src/platz1de/EasyEdit/session/Session.php
+++ b/src/platz1de/EasyEdit/session/Session.php
@@ -134,7 +134,7 @@ class Session
 
 		if (ConfigManager::getHistoryDepth() != -1) {
 			if ($this->historyDepth > ConfigManager::getHistoryDepth()) {
-				$this->past->pop();
+				CleanStorageTask::from([$this->past->pop()->markForDeletion()]);
 				$this->historyDepth--;
 			}
 		}

--- a/src/platz1de/EasyEdit/utils/ConfigManager.php
+++ b/src/platz1de/EasyEdit/utils/ConfigManager.php
@@ -29,6 +29,7 @@ class ConfigManager
 	private static bool $allowOtherHistory;
 	private static int $pathfindingMax;
 	private static int $fillDistance;
+	private static int $historyDepth;
 	private static bool $sendDebug;
 	private static bool $downloadData;
 	private static bool $cacheData;
@@ -48,6 +49,7 @@ class ConfigManager
 		self::$toolCooldown = self::mustGetFloat($config, "tool-cooldown", 0.5);
 
 		self::$allowOtherHistory = self::mustGetBool($config, "allow-history-other", true);
+		self::$historyDepth = self::mustGetInt($config, "history-depth", -1);
 
 		self::$pathfindingMax = self::mustGetInt($config, "pathfinding-max", 1000000);
 		self::$fillDistance = self::mustGetInt($config, "fill-distance", 200);

--- a/src/platz1de/EasyEdit/utils/ConfigManager.php
+++ b/src/platz1de/EasyEdit/utils/ConfigManager.php
@@ -177,6 +177,11 @@ class ConfigManager
 		return self::$fillDistance;
 	}
 
+	public static function getHistoryDepth(): int
+	{
+		return self::$historyDepth;
+	}
+
 	/**
 	 * @return bool
 	 */

--- a/src/platz1de/EasyEdit/utils/ConfigManager.php
+++ b/src/platz1de/EasyEdit/utils/ConfigManager.php
@@ -49,7 +49,7 @@ class ConfigManager
 		self::$toolCooldown = self::mustGetFloat($config, "tool-cooldown", 0.5);
 
 		self::$allowOtherHistory = self::mustGetBool($config, "allow-history-other", true);
-		self::$historyDepth = self::mustGetInt($config, "history-depth", 3);
+		self::$historyDepth = self::mustGetInt($config, "history-depth", -1);
 
 		self::$pathfindingMax = self::mustGetInt($config, "pathfinding-max", 1000000);
 		self::$fillDistance = self::mustGetInt($config, "fill-distance", 200);

--- a/src/platz1de/EasyEdit/utils/ConfigManager.php
+++ b/src/platz1de/EasyEdit/utils/ConfigManager.php
@@ -49,7 +49,7 @@ class ConfigManager
 		self::$toolCooldown = self::mustGetFloat($config, "tool-cooldown", 0.5);
 
 		self::$allowOtherHistory = self::mustGetBool($config, "allow-history-other", true);
-		self::$historyDepth = self::mustGetInt($config, "history-depth", -1);
+		self::$historyDepth = self::mustGetInt($config, "history-depth", 3);
 
 		self::$pathfindingMax = self::mustGetInt($config, "pathfinding-max", 1000000);
 		self::$fillDistance = self::mustGetInt($config, "fill-distance", 200);


### PR DESCRIPTION
This PR adds a configurable undo history depth. Hence, steps are only remembered up to `history-depth`.

The wiki states:
```
Your selection size is mostly only limited by the space the undo-ing data needs (there currently is no option to disable undo).
```
Now, there should be an option to disable undo by setting `history-depth` to 0. (-1 for "infinite")
Hopefully, `CleanStorageTask` is doing what I hope it does. 😅 