### PR TITLE
Refactor packet encoding to use pmmp/ext-encoding

### DIFF
--- a/src/platz1de/EasyEdit/world/blockupdate/InjectingData.php
+++ b/src/platz1de/EasyEdit/world/blockupdate/InjectingData.php
@@ -5,6 +5,7 @@ namespace platz1de\EasyEdit\world\blockupdate;
 use pmmp\encoding\VarInt;
 use pmmp\encoding\ByteBufferWriter;
 use pocketmine\network\mcpe\convert\TypeConverter;
+use pocketmine\network\mcpe\protocol\serializer\CommonTypes;
 use pocketmine\network\mcpe\protocol\types\BlockPosition;
 use pocketmine\utils\Binary;
 
@@ -28,16 +29,14 @@ class InjectingData
         VarInt::writeSignedInt($this->injection, $z);
         VarInt::writeUnsignedInt($this->injection, TypeConverter::getInstance()->getBlockTranslator()->internalIdToNetworkId($id));
         VarInt::writeUnsignedInt($this->injection, 2); //network flag
-        VarInt::writeSignedLong($this->injection, -1); //we don't have any actors
+        VarInt::writeUnsignedLong($this->injection, 0); //we don't have any actors
         VarInt::writeUnsignedInt($this->injection, 0); //not synced
 	}
 
 	public function toProtocol(): string
 	{
 		$serializer = new ByteBufferWriter();
-        VarInt::writeSignedInt($serializer, $this->position->getX());
-        VarInt::writeUnsignedInt($serializer, Binary::unsignInt($this->position->getY()));
-        VarInt::writeSignedInt($serializer, $this->position->getZ());
+        CommonTypes::putBlockPosition($serializer, $this->position);
         VarInt::writeUnsignedInt($serializer, $this->blockCount);
         $serializer->writeByteArray($this->injection->getData());
         VarInt::writeUnsignedInt($serializer, 0); //we don't use the second layer

--- a/src/platz1de/EasyEdit/world/blockupdate/InjectingData.php
+++ b/src/platz1de/EasyEdit/world/blockupdate/InjectingData.php
@@ -2,42 +2,45 @@
 
 namespace platz1de\EasyEdit\world\blockupdate;
 
+use pmmp\encoding\VarInt;
+use pmmp\encoding\ByteBufferWriter;
 use pocketmine\network\mcpe\convert\TypeConverter;
-use pocketmine\network\mcpe\protocol\serializer\PacketSerializer;
 use pocketmine\network\mcpe\protocol\types\BlockPosition;
 use pocketmine\utils\Binary;
 
 class InjectingData
 {
-	private PacketSerializer $injection;
+	private ByteBufferWriter $injection;
 	private int $blockCount = 0;
 	private BlockPosition $position;
 
 	public function __construct(int $x, int $y, int $z)
 	{
 		$this->position = new BlockPosition($x, $y, $z);
-		$this->injection = PacketSerializer::encoder();
+		$this->injection = new ByteBufferWriter();
 	}
 
 	public function writeBlock(int $x, int $y, int $z, int $id): void
-	{
+    {
 		$this->blockCount++;
-		$this->injection->putVarInt($x);
-		$this->injection->putUnsignedVarInt(Binary::unsignInt($y));
-		$this->injection->putVarInt($z);
-		$this->injection->putUnsignedVarInt(TypeConverter::getInstance()->getBlockTranslator()->internalIdToNetworkId($id));
-		$this->injection->putUnsignedVarInt(2); //network flag
-		$this->injection->putUnsignedVarLong(-1); //we don't have any actors
-		$this->injection->putUnsignedVarInt(0); //not synced
+        VarInt::writeSignedInt($this->injection, $x);
+        VarInt::writeUnsignedInt($this->injection, Binary::unsignInt($y));
+        VarInt::writeSignedInt($this->injection, $z);
+        VarInt::writeUnsignedInt($this->injection, TypeConverter::getInstance()->getBlockTranslator()->internalIdToNetworkId($id));
+        VarInt::writeUnsignedInt($this->injection, 2); //network flag
+        VarInt::writeSignedLong($this->injection, -1); //we don't have any actors
+        VarInt::writeUnsignedInt($this->injection, 0); //not synced
 	}
 
 	public function toProtocol(): string
 	{
-		$serializer = PacketSerializer::encoder();
-		$serializer->putBlockPosition($this->position);
-		$serializer->putUnsignedVarInt($this->blockCount);
-		$serializer->put($this->injection->getBuffer());
-		$serializer->putUnsignedVarInt(0); //we don't use the second layer
-		return $serializer->getBuffer();
+		$serializer = new ByteBufferWriter();
+        VarInt::writeSignedInt($serializer, $this->position->getX());
+        VarInt::writeUnsignedInt($serializer, Binary::unsignInt($this->position->getY()));
+        VarInt::writeSignedInt($serializer, $this->position->getZ());
+        VarInt::writeUnsignedInt($serializer, $this->blockCount);
+        $serializer->writeByteArray($this->injection->getData());
+        VarInt::writeUnsignedInt($serializer, 0); //we don't use the second layer
+		return $serializer->getData();
 	}
 }

--- a/src/platz1de/EasyEdit/world/blockupdate/InjectingData.php
+++ b/src/platz1de/EasyEdit/world/blockupdate/InjectingData.php
@@ -2,8 +2,8 @@
 
 namespace platz1de\EasyEdit\world\blockupdate;
 
-use pmmp\encoding\VarInt;
 use pmmp\encoding\ByteBufferWriter;
+use pmmp\encoding\VarInt;
 use pocketmine\network\mcpe\convert\TypeConverter;
 use pocketmine\network\mcpe\protocol\serializer\CommonTypes;
 use pocketmine\network\mcpe\protocol\types\BlockPosition;
@@ -22,24 +22,24 @@ class InjectingData
 	}
 
 	public function writeBlock(int $x, int $y, int $z, int $id): void
-    {
+	{
 		$this->blockCount++;
-        VarInt::writeSignedInt($this->injection, $x);
-        VarInt::writeUnsignedInt($this->injection, Binary::unsignInt($y));
-        VarInt::writeSignedInt($this->injection, $z);
-        VarInt::writeUnsignedInt($this->injection, TypeConverter::getInstance()->getBlockTranslator()->internalIdToNetworkId($id));
-        VarInt::writeUnsignedInt($this->injection, 2); //network flag
-        VarInt::writeUnsignedLong($this->injection, 0); //we don't have any actors
-        VarInt::writeUnsignedInt($this->injection, 0); //not synced
+		VarInt::writeSignedInt($this->injection, $x);
+		VarInt::writeUnsignedInt($this->injection, Binary::unsignInt($y));
+		VarInt::writeSignedInt($this->injection, $z);
+		VarInt::writeUnsignedInt($this->injection, TypeConverter::getInstance()->getBlockTranslator()->internalIdToNetworkId($id));
+		VarInt::writeUnsignedInt($this->injection, 2); //network flag
+		VarInt::writeUnsignedLong($this->injection, 0); //we don't have any actors
+		VarInt::writeUnsignedInt($this->injection, 0); //not synced
 	}
 
 	public function toProtocol(): string
 	{
 		$serializer = new ByteBufferWriter();
-        CommonTypes::putBlockPosition($serializer, $this->position);
-        VarInt::writeUnsignedInt($serializer, $this->blockCount);
-        $serializer->writeByteArray($this->injection->getData());
-        VarInt::writeUnsignedInt($serializer, 0); //we don't use the second layer
+		CommonTypes::putBlockPosition($serializer, $this->position);
+		VarInt::writeUnsignedInt($serializer, $this->blockCount);
+		$serializer->writeByteArray($this->injection->getData());
+		VarInt::writeUnsignedInt($serializer, 0); //we don't use the second layer
 		return $serializer->getData();
 	}
 }

--- a/src/platz1de/EasyEdit/world/blockupdate/UpdateSubChunkBlocksInjector.php
+++ b/src/platz1de/EasyEdit/world/blockupdate/UpdateSubChunkBlocksInjector.php
@@ -16,7 +16,8 @@ use pocketmine\network\mcpe\protocol\UpdateSubChunkBlocksPacket;
  *
  * Warning: If the packet syntax changes, this will silently break, not displaying any changes to the client
  */
-class UpdateSubChunkBlocksInjector extends DataPacket implements ClientboundPacket {
+class UpdateSubChunkBlocksInjector extends DataPacket implements ClientboundPacket 
+{
     public const NETWORK_ID = ProtocolInfo::UPDATE_SUB_CHUNK_BLOCKS_PACKET;
 
     /**
@@ -24,24 +25,28 @@ class UpdateSubChunkBlocksInjector extends DataPacket implements ClientboundPack
      */
     private string $rawData;
 
-    public static function create(string $data): self {
+    public static function create(string $data): self 
+    {
         $result = new self;
         $result->rawData = $data;
         return $result;
     }
 
-    protected function decodePayload(ByteBufferReader $in): void {
+    protected function decodePayload(ByteBufferReader $in): void 
+    {
         $prev = $in->getOffset();
         $mock = new UpdateSubChunkBlocksPacket();
         $mock->decodePayload($in);
         $this->rawData = substr($in->getData(), $prev, $in->getOffset() - $prev);
     }
 
-    protected function encodePayload(ByteBufferWriter $out): void {
+    protected function encodePayload(ByteBufferWriter $out): void 
+    {
         $out->writeByteArray($this->rawData);
     }
 
-    public function handle(PacketHandlerInterface $handler): bool {
+    public function handle(PacketHandlerInterface $handler): bool 
+    {
         //Apparently some plugins just blindly handle packets sent to the network, so we need to emulate its behavior
         $mock = new UpdateSubChunkBlocksPacket();
         $mock->decodePayload(new ByteBufferReader($this->rawData));

--- a/src/platz1de/EasyEdit/world/blockupdate/UpdateSubChunkBlocksInjector.php
+++ b/src/platz1de/EasyEdit/world/blockupdate/UpdateSubChunkBlocksInjector.php
@@ -8,7 +8,6 @@ use pocketmine\network\mcpe\protocol\ClientboundPacket;
 use pocketmine\network\mcpe\protocol\DataPacket;
 use pocketmine\network\mcpe\protocol\PacketHandlerInterface;
 use pocketmine\network\mcpe\protocol\ProtocolInfo;
-use pocketmine\network\mcpe\protocol\serializer\PacketSerializer;
 use pocketmine\network\mcpe\protocol\UpdateSubChunkBlocksPacket;
 
 /**
@@ -16,40 +15,40 @@ use pocketmine\network\mcpe\protocol\UpdateSubChunkBlocksPacket;
  *
  * Warning: If the packet syntax changes, this will silently break, not displaying any changes to the client
  */
-class UpdateSubChunkBlocksInjector extends DataPacket implements ClientboundPacket 
+class UpdateSubChunkBlocksInjector extends DataPacket implements ClientboundPacket
 {
-    public const NETWORK_ID = ProtocolInfo::UPDATE_SUB_CHUNK_BLOCKS_PACKET;
+	public const NETWORK_ID = ProtocolInfo::UPDATE_SUB_CHUNK_BLOCKS_PACKET;
 
-    /**
-     * Binary data to inject
-     */
-    private string $rawData;
+	/**
+	 * Binary data to inject
+	 */
+	private string $rawData;
 
-    public static function create(string $data): self 
-    {
-        $result = new self;
-        $result->rawData = $data;
-        return $result;
-    }
+	public static function create(string $data): self
+	{
+		$result = new self;
+		$result->rawData = $data;
+		return $result;
+	}
 
-    protected function decodePayload(ByteBufferReader $in): void 
-    {
-        $prev = $in->getOffset();
-        $mock = new UpdateSubChunkBlocksPacket();
-        $mock->decodePayload($in);
-        $this->rawData = substr($in->getData(), $prev, $in->getOffset() - $prev);
-    }
+	protected function decodePayload(ByteBufferReader $in): void
+	{
+		$prev = $in->getOffset();
+		$mock = new UpdateSubChunkBlocksPacket();
+		$mock->decodePayload($in);
+		$this->rawData = substr($in->getData(), $prev, $in->getOffset() - $prev);
+	}
 
-    protected function encodePayload(ByteBufferWriter $out): void 
-    {
-        $out->writeByteArray($this->rawData);
-    }
+	protected function encodePayload(ByteBufferWriter $out): void
+	{
+		$out->writeByteArray($this->rawData);
+	}
 
-    public function handle(PacketHandlerInterface $handler): bool 
-    {
-        //Apparently some plugins just blindly handle packets sent to the network, so we need to emulate its behavior
-        $mock = new UpdateSubChunkBlocksPacket();
-        $mock->decodePayload(new ByteBufferReader($this->rawData));
-        return $mock->handle($handler);
-    }
+	public function handle(PacketHandlerInterface $handler): bool
+	{
+		//Apparently some plugins just blindly handle packets sent to the network, so we need to emulate its behavior
+		$mock = new UpdateSubChunkBlocksPacket();
+		$mock->decodePayload(new ByteBufferReader($this->rawData));
+		return $mock->handle($handler);
+	}
 }

--- a/src/platz1de/EasyEdit/world/blockupdate/UpdateSubChunkBlocksInjector.php
+++ b/src/platz1de/EasyEdit/world/blockupdate/UpdateSubChunkBlocksInjector.php
@@ -2,6 +2,8 @@
 
 namespace platz1de\EasyEdit\world\blockupdate;
 
+use pmmp\encoding\ByteBufferReader;
+use pmmp\encoding\ByteBufferWriter;
 use pocketmine\network\mcpe\protocol\ClientboundPacket;
 use pocketmine\network\mcpe\protocol\DataPacket;
 use pocketmine\network\mcpe\protocol\PacketHandlerInterface;
@@ -14,40 +16,35 @@ use pocketmine\network\mcpe\protocol\UpdateSubChunkBlocksPacket;
  *
  * Warning: If the packet syntax changes, this will silently break, not displaying any changes to the client
  */
-class UpdateSubChunkBlocksInjector extends DataPacket implements ClientboundPacket
-{
-	public const NETWORK_ID = ProtocolInfo::UPDATE_SUB_CHUNK_BLOCKS_PACKET;
+class UpdateSubChunkBlocksInjector extends DataPacket implements ClientboundPacket {
+    public const NETWORK_ID = ProtocolInfo::UPDATE_SUB_CHUNK_BLOCKS_PACKET;
 
-	/**
-	 * Binary data to inject
-	 */
-	private string $rawData;
+    /**
+     * Binary data to inject
+     */
+    private string $rawData;
 
-	public static function create(string $data): self
-	{
-		$result = new self;
-		$result->rawData = $data;
-		return $result;
-	}
+    public static function create(string $data): self {
+        $result = new self;
+        $result->rawData = $data;
+        return $result;
+    }
 
-	protected function decodePayload(PacketSerializer $in): void
-	{
-		$prev = $in->getOffset();
-		$mock = new UpdateSubChunkBlocksPacket();
-		$mock->decodePayload($in);
-		$this->rawData = substr($in->getBuffer(), $prev, $in->getOffset() - $prev);
-	}
+    protected function decodePayload(ByteBufferReader $in): void {
+        $prev = $in->getOffset();
+        $mock = new UpdateSubChunkBlocksPacket();
+        $mock->decodePayload($in);
+        $this->rawData = substr($in->getData(), $prev, $in->getOffset() - $prev);
+    }
 
-	protected function encodePayload(PacketSerializer $out): void
-	{
-		$out->put($this->rawData);
-	}
+    protected function encodePayload(ByteBufferWriter $out): void {
+        $out->writeByteArray($this->rawData);
+    }
 
-	public function handle(PacketHandlerInterface $handler): bool
-	{
-		//Apparently some plugins just blindly handle packets sent to the network, so we need to emulate its behavior
-		$mock = new UpdateSubChunkBlocksPacket();
-		$mock->decodePayload(PacketSerializer::decoder($this->rawData, 0));
-		return $mock->handle($handler);
-	}
+    public function handle(PacketHandlerInterface $handler): bool {
+        //Apparently some plugins just blindly handle packets sent to the network, so we need to emulate its behavior
+        $mock = new UpdateSubChunkBlocksPacket();
+        $mock->decodePayload(new ByteBufferReader($this->rawData));
+        return $mock->handle($handler);
+    }
 }


### PR DESCRIPTION
After reading through the changes you requested on the other pull request, I decided to propose these. I hope they're to your liking!
I used a SignedLong here: `VarInt::writeSignedLong($this->injection, -1);` — to my understanding, a negative value can’t be unsigned. If this was intentional (e.g., required by the Bedrock protocol), feel free to request changes.